### PR TITLE
Fixed config.toml autostart

### DIFF
--- a/etc/skel/.config/nimdow/config.toml
+++ b/etc/skel/.config/nimdow/config.toml
@@ -43,15 +43,8 @@
 exec = [
   "xsetroot -cursor_name left_ptr",
   "~/.config/nimdow/autostart.sh",
-  "~/.config/nimdow/nimdowstatus/NimdowStatus"
+  "~/.config/nimdow/nimdowstatus/NimdowStatus",
   "~/.config/nimdow/start-picom.sh",
-  "/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1",
-  "nitrogen --restore",
-  "nm-applet",
-  "volumeicon",
-  "blueberry-tray",
-  #"firefox",
-  #"st",
 ]
 
 [settings]

--- a/etc/skel/.config/nimdow/config.toml
+++ b/etc/skel/.config/nimdow/config.toml
@@ -44,7 +44,6 @@ exec = [
   "xsetroot -cursor_name left_ptr",
   "~/.config/nimdow/autostart.sh",
   "~/.config/nimdow/nimdowstatus/NimdowStatus",
-  "~/.config/nimdow/start-picom.sh",
 ]
 
 [settings]


### PR DESCRIPTION
No need to auto start all those applications e.g picom, berry-tray, ect.. ect.. as they are already in the autostart.sh script you have provided, so I have removed them from the config.toml settings 