### PR TITLE
Remove slstatus from autostart.sh

### DIFF
--- a/etc/skel/.config/nimdow/autostart.sh
+++ b/etc/skel/.config/nimdow/autostart.sh
@@ -27,7 +27,7 @@ run "/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1"
 picom -b  --config ~/.config/nimdow/picom.conf &
 run "numlockx on"
 run "volumeicon"
-run slstatus &
+#run slstatus &
 sxhkd -c ~/.config/nimdow/sxhkd/sxhkdrc &
 #run "nitrogen --restore"
 run "conky -c $HOME/.config/nimdow/system-overview"


### PR DESCRIPTION
this is why you seen blinking color, slstatus was auto starting which was over writting the NimdowStatus program, I have commented out the slstatus from the autostart.sh file to allow NimdowStatus to work correctly